### PR TITLE
fix typo: "appple" to "Apple" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ OpenAPI通用调用接口，帮助开发者访问开放平台open api(http://ope
 
 - 在新浪微博开放平台注册并创建应用
 - 已定义本应用的授权回调页  
-- 已选择应用为iOS平台，并正确填写Bundle id和appple id
+- 已选择应用为iOS平台，并正确填写Bundle ID和Apple ID
 
 注: 关于授权回调页对移动客户端应用来说对用户是不可见的，所以定义为何种形式都将不影响，但是没有定义将无法使用SDK认证登录。建议使用默认回调页 https://api.weibo.com/oauth2/default.html 
 


### PR DESCRIPTION
|before|after|
|---|---|
|Bundle id|Bundle ID|
|appple id|Apple ID|
原文多了个 "p"